### PR TITLE
ci: Deprecate cargo-tarpaulin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
       - name: Run cargo-tarpaulin
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,8 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-          components: rustfmt,clippy,cargo-tarpaulin
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
       - name: Run cargo-tarpaulin
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,5 +116,5 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/cargo@v1
         with:
-          command: cargo-tarpaulin
+          command: tarpaulin
           args: --all-features --workspace --ignore-tests --out Lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
           profile: minimal
           override: true
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+        uses: actions-rs/cargo@v1
         with:
-          args: '--all-features --workspace --ignore-tests --out Lcov'
+          command: cargo-tarpaulin
+          args: --all-features --workspace --ignore-tests --out Lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+          components: rustfmt,clippy,cargo-tarpaulin
       - name: Run cargo-tarpaulin
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,23 +98,3 @@ jobs:
         with:
           command: publish
           args: -p cherryrgb --dry-run
-
-  coverage:
-    name: Code coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/cargo@v1
-        with:
-          command: tarpaulin
-          args: --all-features --workspace --ignore-tests --out Lcov


### PR DESCRIPTION
Cargo-tarpaulin is way too slow to build.
Just removing it - it's unnecessary for this small project anyway.