### PR TITLE
Tested MX Board 3.0 S and README edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.vscode

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -12,7 +12,7 @@ Please send a Pull Request with your keyboard model once you can report on suppo
 | Name                          | PID                  | Tested? | Features (Animation / Custom Colors / Key Remap) |
 | ----------------------------- | -------------------- | --------| ------------------------------------------------ |
 | MX BOARD 3.0S FL NBL          | 0x0077               | ❌      | ❌ / ❌ / ❌ |
-| MX BOARD 3.0S FL RGB          | 0x0079               | ❌      | ❌ / ❌ / ❌ |
+| MX BOARD 3.0S FL RGB          | 0x0079               | ✅      | ✅ / ✅ / ❌ |
 | MX BOARD 3.0S FL RGB KOREAN   | 0x0083               | ❌      | ❌ / ❌ / ❌ |
 | MX 1.0 FL BL                  | 0x00AB               | ❌      | ❌ / ❌ / ❌ |
 | MX BOARD 1.0 TKL RGB          | 0x00AC               | ❌      | ❌ / ❌ / ❌ |

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@
 [![GitHub release](https://img.shields.io/github/v/release/skraus-dev/cherryrgb-rs?include_prereleases)](https://github.com/skraus-dev/cherryrgb-rs/releases/latest)
 [![CI](https://github.com/skraus-dev/cherryrgb-rs/workflows/CI/badge.svg)](https://github.com/skraus-dev/cherryrgb-rs/actions)
 
-Tested with
-* Cherry Keyboard G80-3000N RGB (046a:00dd)
-* Cherry Keyboard MX10.0N       (046a:00df)
+## Compatibility
 
-See [Compatibility table](COMPATIBILITY.md)
+To see which devices are tested take a look at the [Compatibility Table](COMPATIBILITY.md).
 
 ## Features
 
@@ -31,7 +29,8 @@ Please see [Docs.rs](https://docs.rs/cherryrgb)
 ## CLI
 
 Get usage help
-```
+
+```shell
 # Top level
 ./cherryrgb_cli --help
 
@@ -47,7 +46,7 @@ Set LED animation
 * Speed: slow
 * Brightness: medium
 
-```
+```shell
 ./cherryrgb_cli --brightness medium animation rain slow 00ff00
 ```
 
@@ -57,7 +56,7 @@ Set custom key colors
 * Key 0 color: #ff00ff
 * Key 1 color: #0000ff
 
-```
+```shell
 ./cherryrgb_cli --brightness full custom-colors ff00ff 0000ff
 ```
 
@@ -65,18 +64,17 @@ Set custom key colors
 
 ### Dependencies
 
-- Rust (https://www.rust-lang.org/tools/install)
+* Rust (<https://www.rust-lang.org/tools/install>)
 
 ### Clone & Build
 
-```bash
+```shell
 git clone https://github.com/skraus-dev/cherryrgb-rs.git
 cd cherryrgb-rs
 cargo build
 ```
 
 Now you can run the binary from `./target/debug/cherryrgb_cli`
-
 
 ## Troubleshooting
 
@@ -100,11 +98,12 @@ In the following example we assume your product id is **0x00dd**.
 ## Disclaimer
 
 Use at your own risk.
-This project is not affiliated or endorsed by Cherry GmbH. 
+This project is not affiliated or endorsed by Cherry GmbH.
 
 ## Changelog
 
 ### v0.2.2 - 29/03/2023
+
 * fix: Skip kernel driver detaching for non-unix platforms
 * Refactor parameter handling and help for enums (by @felfert)
 * Filter unsupported Cherry keyboards (by @felfert)
@@ -112,16 +111,20 @@ This project is not affiliated or endorsed by Cherry GmbH.
 * Add example udev rules file
 
 ### v0.2.1 - 08/08/2021
+
 * Refactor internal API
 * Models: Correct data_offset and checksum fields from u8 to u16
 
 ### v0.2.0 - 29/07/2021
+
 * API: Improve usability by wrapping device communication inside struct CherryKeyboard
 
 ### v0.1.2 - 28/07/2021
+
 * Implement enumerating all connected Cherry GmbH devices
 
 ### v0.1.1 - 28/07/2021
+
 * Differentiate between payload and flags/commands
 * Rename LightingModes: Radar, Stars
 * Fix bug with missing padding
@@ -129,4 +132,5 @@ This project is not affiliated or endorsed by Cherry GmbH.
 * General code cleanup
 
 ### v0.1.0 - 24/07/2021
+
 * Initial release

--- a/cherryrgb/src/lib.rs
+++ b/cherryrgb/src/lib.rs
@@ -71,10 +71,14 @@ pub use rusb;
 // Constants
 /// USB Vendor ID - Cherry GmbH
 pub const CHERRY_USB_VID: u16 = 0x046a;
+
 /// USB Product ID - G80-3000N RGB TKL Keyboard
 pub const G80_3000N_RGB_TKL_USB_PID: u16 = 0x00dd;
 /// USB Product ID - MX 10.0N Keyboard
 pub const MX10N_USB_PID: u16 = 0x00df;
+/// USB Product ID - MX Board 3.0 S RGB Keyboard
+pub const MX30S_RGB_PID: u16 = 0x0079;
+
 const INTERFACE_NUM: u8 = 1;
 const INTERRUPT_EP: u8 = 0x82;
 static TIMEOUT: Duration = Duration::from_millis(1000);


### PR DESCRIPTION
Hey,

I tested the MX Board 3.0 S. Animations and custom colors work like a charm!

I also added the PID of the device in lib.rs.
However I don't know why this is necessary because the IDs are not used anywhere else in the code.
Could they be removed from lib.rs?

The README file had this "tested with" section which I thought would make more sense if it just had a link to the actual compatibility table. This is just to not clutter the actual README with compatibility information of individual devices 😄 