### PR TITLE
Define keyindex and keymap payloads

### DIFF
--- a/cherryrgb/src/lib.rs
+++ b/cherryrgb/src/lib.rs
@@ -78,6 +78,10 @@ const INTERFACE_NUM: u8 = 1;
 const INTERRUPT_EP: u8 = 0x82;
 static TIMEOUT: Duration = Duration::from_millis(1000);
 
+/// (64 byte packet - 4 byte packet header - 4 byte payload header)
+const CHUNK_SIZE: usize = 56;
+const TOTAL_KEYS: usize = 126;
+
 /// Calculate packet checksum (index 1 in payload)
 fn calc_checksum(payload_type: u8, data: &[u8]) -> u16 {
     let sum = data.iter().map(|&i| i as u16).sum::<u16>() + (payload_type as u16);

--- a/cherryrgb/src/lib.rs
+++ b/cherryrgb/src/lib.rs
@@ -84,7 +84,15 @@ const TOTAL_KEYS: usize = 126;
 
 /// Calculate packet checksum (index 1 in payload)
 fn calc_checksum(payload_type: u8, data: &[u8]) -> u16 {
-    let sum = data.iter().map(|&i| i as u16).sum::<u16>() + (payload_type as u16);
+    // FIXME: Cleanup this quickfix..
+    let to_hash = match payload_type {
+        // Only hash 4 bytes if payload is (GetKeymap || GetKeyIndexes)
+        0x7 | 0x1B => {
+            std::cmp::min(data.len(), 0x4)
+        },
+        _ => data.len(),
+    };
+    let sum = data[..to_hash].iter().map(|&i| i as u16).sum::<u16>() + (payload_type as u16);
 
     sum
 }

--- a/cherryrgb/src/models.rs
+++ b/cherryrgb/src/models.rs
@@ -1,6 +1,7 @@
 use crate::{
     calc_checksum,
     extensions::{OwnRGB8, ToVec},
+    CHUNK_SIZE, TOTAL_KEYS,
 };
 use anyhow::{anyhow, Result};
 use binrw::{binrw, until_eof, BinRead, BinWrite, BinWriterExt};
@@ -238,22 +239,16 @@ impl TryFrom<Vec<ProfileKey>> for CustomKeyLeds {
 }
 
 impl CustomKeyLeds {
-    /// (64 byte packet - 4 byte packet header - 4 byte payload header)
-    const CHUNK_SIZE: usize = 56;
-    const TOTAL_KEYS: usize = 126;
-
     /// Initialize with inactive colors (000000) for all keys
     pub fn new() -> Self {
         Self {
-            key_leds: (0..CustomKeyLeds::TOTAL_KEYS)
-                .map(|_| OwnRGB8::default())
-                .collect(),
+            key_leds: (0..TOTAL_KEYS).map(|_| OwnRGB8::default()).collect(),
         }
     }
 
     /// Initialize from collection of RGB8 values
     pub fn from_leds<C: Into<OwnRGB8>>(key_leds: Vec<C>) -> Result<Self> {
-        if key_leds.len() > CustomKeyLeds::TOTAL_KEYS {
+        if key_leds.len() > TOTAL_KEYS {
             return Err(anyhow!("Invalid number of key leds"));
         }
 
@@ -277,10 +272,10 @@ impl CustomKeyLeds {
         let key_data = self.to_vec();
 
         let result = key_data
-            .chunks(CustomKeyLeds::CHUNK_SIZE)
+            .chunks(CHUNK_SIZE)
             .enumerate()
             .map(|(index, chunk)| {
-                let data_offset = index * CustomKeyLeds::CHUNK_SIZE;
+                let data_offset = index * CHUNK_SIZE;
 
                 Payload::SetCustomLED {
                     data_offset: data_offset as u16,

--- a/cherryrgb/src/models.rs
+++ b/cherryrgb/src/models.rs
@@ -73,6 +73,15 @@ pub enum Brightness {
     Full = 4,
 }
 
+/// Represents the mapping of a key to a certain function/keycode
+#[binrw]
+#[derive(Clone, Debug)]
+pub struct Keymap {
+    pub modifier: u8,
+    pub unk: u8,
+    pub keycode: u8,
+}
+
 pub trait PayloadType {
     fn payload_type(&self) -> u8;
 }

--- a/cherryrgb/src/models.rs
+++ b/cherryrgb/src/models.rs
@@ -91,7 +91,13 @@ pub enum Payload {
     #[br(pre_assert(payload_type == 0x5))]
     Unknown5 { unk: u8 },
     #[br(pre_assert(payload_type == 0x7))]
-    Unknown7 { data_len: u8, data_offset: u16 },
+    GetKeymap {
+        data_len: u8,
+        data_offset: u16,
+        padding: u8,
+        #[br(count = data_len)]
+        keymap: Vec<u8>,
+    },
     #[br(pre_assert(payload_type == 0x6))]
     SetAnimation {
         unknown: [u8; 5],
@@ -113,7 +119,13 @@ pub enum Payload {
         key_leds_data: Vec<u8>,
     },
     #[br(pre_assert(payload_type == 0x1B))]
-    Unknown1B { data_len: u8, data_offset: u8 },
+    GetKeyIndexes {
+        data_len: u8,
+        data_offset: u16,
+        padding: u8,
+        #[br(count = data_len)]
+        key_data: Vec<u8>,
+    },
     Unhandled {
         #[br(parse_with = until_eof)]
         data: Vec<u8>,
@@ -127,10 +139,10 @@ impl PayloadType for Payload {
             Payload::TransactionEnd => 0x2,
             Payload::Unknown3 { .. } => 0x3,
             Payload::Unknown5 { .. } => 0x5,
-            Payload::Unknown7 { .. } => 0x7,
+            Payload::GetKeymap { .. } => 0x7,
             Payload::SetAnimation { .. } => 0x6,
             Payload::SetCustomLED { .. } => 0xB,
-            Payload::Unknown1B { .. } => 0x1B,
+            Payload::GetKeyIndexes { .. } => 0x1B,
             _ => {
                 log::error!("Unhandled Payload: {:?}", self);
                 0xFF


### PR DESCRIPTION
* Implement payload definition for getting available keyboard keys (as zero-based u8 index)
* Implement payload definition for getting available keyboard mapping (thx @felfert for the leading research)
* Quickfix: For these two new payload types, the checksum calculation only takes a fraction of the payload into consideration