### PR TITLE
Auto-detach kernel driver (Fix #22)

### DIFF
--- a/cherryrgb/src/lib.rs
+++ b/cherryrgb/src/lib.rs
@@ -182,15 +182,9 @@ impl CherryKeyboard {
 
         // Skip kernel driver detachment for non-unix platforms
         if cfg!(unix) {
-            let kernel_driver_active = device_handle
-                .kernel_driver_active(INTERFACE_NUM)
-                .context("kernel_driver_active")?;
-
-            if kernel_driver_active {
-                device_handle
-                    .detach_kernel_driver(INTERFACE_NUM)
-                    .context("Failed to detach active kernel driver")?;
-            }
+            device_handle
+                .set_auto_detach_kernel_driver(true)
+                .context("Failed to detach active kernel driver")?;
         }
 
         device_handle


### PR DESCRIPTION
Hi Sebastian,

Unfortunately with your latest changes in master, cherryrgb_cli crashes here (will file a separate Issue for that tommorow).
Therefore my fix for #22 is **NOT** against master, but against the tag **0.2.3**
