### PR TITLE
CI: Fix paths to copy into release archive

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,8 +78,8 @@ jobs:
 
           cp target/${{ matrix.job.target }}/release/$BINARY_NAME release_tmp/
           cp README.md release_tmp/
-          cp COMPATIBILITY.md release_tmp/
           cp LICENSE release_tmp/
+          cp ./docs/COMPATIBILITY.md release_tmp/
 
           ###### For linux builds, copy the udev directory too ######
           if [[ ${{ matrix.job.os-name }} == linux ]]; then

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,6 +81,8 @@ jobs:
           cp LICENSE release_tmp/
           cp ./docs/COMPATIBILITY.md release_tmp/
 
+          cp -r examples release_tmp/
+
           ###### For linux builds, copy the udev directory too ######
           if [[ ${{ matrix.job.os-name }} == linux ]]; then
             cp -r udev release_tmp/


### PR DESCRIPTION
# Description

- Fix paths of COMPATIBILITY.md to copy into release archive
- Copy examples/ directory into release archive too


## Type of change

- [X] CI related change
