### PR TITLE
Add install of new dependencies in CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev clang llvm
       - name: Checkout repository
         uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -35,6 +37,8 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev clang llvm
       - name: Checkout repository
         uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -48,6 +52,8 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev clang llvm
       - name: Checkout repository
         uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -62,6 +68,8 @@ jobs:
     name: Publish dry run
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev clang llvm
       - name: Checkout repository
         uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
No template filled here, because this is about github actions, not the actual code.
This fixes the github action ci.yml

- This PR is (unusual) from master -> to master, because github workflows are active in the master branch only and I therefore could not test them in a topic branch.
- Perhaps the cd.yaml need a similar change, but I obviously cannot test this

The actual issue:
A new build dependency is introduced indirectly by the uhid-virt crate.
This lead to failing CI github action in my previous PR #35

This PR adds an install step for adding these dependencies which fixes that problem.

Cheers
 -Fritz

