### PR TITLE
Implement new workflow

### DIFF
--- a/.github/workflows/new-cd.yml
+++ b/.github/workflows/new-cd.yml
@@ -1,0 +1,43 @@
+name: Publish
+
+on:
+  workflow_call:
+    inputs:
+      artifact-id:
+        required: true
+        type: string
+  workflow_dispatch:
+ 
+jobs:
+  publish-github:
+    if: ${{ github.ref_type == 'tag' && github.event_name != 'workflow_dispatch' }}
+    name: Publish to GitHub
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fetch artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.artifact-id }}
+    - name: Calculate checksums
+      shell: bash
+      run: |
+        for tgz in *.tar.gz ; do
+          sha256sum ${tgz} > $(basename ${tgz} .tar.gz).sha256
+        done
+    - name: Release assets
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          *.tar.gz
+          *.sha256
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+  publish-cargo:
+    name: Publish to Cargo
+    if: ${{ github.ref_type == 'tag' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Publish crate
+        run: cargo publish -p cherryrgb --token ${{ secrets.CARGO_API_KEY }}

--- a/.github/workflows/new-ci.yml
+++ b/.github/workflows/new-ci.yml
@@ -157,7 +157,7 @@ jobs:
     - name: Build in container
       id: build_foreign
       if: ${{ ! matrix.job.native }}
-      uses: felfert/run-on-arch-action@master
+      uses: felfert/run-on-arch-action@custom
       with:
         arch: ${{ matrix.job.foreign_arch }}
         distro: ${{ matrix.job.foreign_distro }}

--- a/.github/workflows/new-ci.yml
+++ b/.github/workflows/new-ci.yml
@@ -122,6 +122,13 @@ jobs:
           native: false
           foreign_arch: i686
           foreign_distro: ubuntu_latest
+        - os: ubuntu-latest
+          assetname: linux-ppc64le
+          target: powerpc64le-unknown-linux-gnu
+          buildopts: "--all --features uhid"
+          native: false
+          foreign_arch: ppc64le
+          foreign_distro: ubuntu_latest
     runs-on: ${{ matrix.job.os }}
     name: Build for ${{ matrix.job.target }}
     steps:

--- a/.github/workflows/new-ci.yml
+++ b/.github/workflows/new-ci.yml
@@ -162,6 +162,7 @@ jobs:
         arch: ${{ matrix.job.foreign_arch }}
         distro: ${{ matrix.job.foreign_distro }}
         githubToken: ${{ github.token }}
+        cachedImageTag: "rust-stable-toolchain-with-libclang-${{ matrix.job.foreign_arch }}-${{ matrix.job.foreign_distro }}"
         install: |
           ${{ env.INSTDEPS }} curl
           ${{ env.INSTCARGO }} --default-host ${{ matrix.job.target }}

--- a/.github/workflows/new-ci.yml
+++ b/.github/workflows/new-ci.yml
@@ -1,0 +1,240 @@
+name: New CI
+
+on:
+  push:
+    branches:
+      'master'
+    tags:
+      '[0-9]+\.[0-9]+\.[0-9]+'
+  pull_request:
+    branches:
+      - 'master'
+    paths-ignore:
+      - 'LICENSE'
+      - '**/*.md'
+      - '.github/**/*'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  DEBIAN_FRONTEND: noninteractive
+  INSTDEPS: "apt-get update && apt-get install -y libclang-dev clang llvm"
+  INSTCARGO: "curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | bash -s -- -y -q"
+
+jobs:
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install build dependencies
+        run: sudo sh -c "${{ env.INSTDEPS }}"
+      - run: cargo test --all-features --workspace
+
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install build dependencies
+        run: sudo sh -c "${{ env.INSTDEPS }}"
+      - name: Clippy check
+        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install build dependencies
+        run: sudo sh -c "${{ env.INSTDEPS }}"
+      - name: Check documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --document-private-items --all-features --workspace
+
+  publish-dry-run:
+    name: Publish dry run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Publish dry-run
+        run: cargo publish -p cherryrgb --dry-run
+
+  clean:
+    if: ${{ github.event_name != 'pull_request' }} # If this is a pull request, stop here
+    name: Clean before matrix build
+    needs: [test, clippy, rustfmt, docs, publish-dry-run]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean target
+        run: rm -rf target
+
+  build:
+    needs: [clean]
+    strategy:
+      matrix:
+        # Name of the tar archives: <assetprefix>-<tag>-<assetname>.tar.gz
+        assetprefix: [cherryrgb-rs]
+        job:
+        - os: ubuntu-latest
+          assetname: linux-x86_64
+          target: x86_64-unknown-linux-gnu
+          buildopts: "--all --features uhid"
+          installdeps: true
+          native: true
+        - os: macos-latest
+          assetname: macos-x86_64
+          target: x86_64-apple-darwin
+          buildopts: ""
+          installdeps: false
+          native: true
+        - os: windows-latest
+          assetname: windows-x86_64
+          target: x86_64-pc-windows-msvc
+          buildopts: ""
+          installdeps: false
+          native: true
+        - os: ubuntu-latest
+          assetname: linux-arm64
+          target: aarch64-unknown-linux-gnu
+          buildopts: "--all --features uhid"
+          native: false
+          foreign_arch: aarch64
+          foreign_distro: ubuntu_latest
+        - os: ubuntu-latest
+          assetname: linux-i686
+          target: i686-unknown-linux-gnu
+          buildopts: "--all --features uhid"
+          native: false
+          foreign_arch: i686
+          foreign_distro: ubuntu_latest
+    runs-on: ${{ matrix.job.os }}
+    name: Build for ${{ matrix.job.target }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Install native build dependencies
+      if: ${{ matrix.job.installdeps && matrix.job.native }}
+      run: sudo sh -c "${{ env.INSTDEPS }}"
+    - name: Retrieve target cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          target
+          dotcargo.tgz
+        key: ${{ matrix.job.target }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          ${{ matrix.job.target }}
+        enableCrossOsArchive: true
+    - name: Build native
+      if: ${{ matrix.job.native }}
+      shell: bash
+      run: |
+        test -f dotcargo.tgz && tar xCf ${HOME} dotcargo.tgz || true
+        cargo build --release --target ${{ matrix.job.target }} ${{ matrix.job.buildopts }}
+        tar czCf ${HOME} dotcargo.tgz .cargo
+    - name: Build in container
+      id: build_foreign
+      if: ${{ ! matrix.job.native }}
+      uses: felfert/run-on-arch-action@master
+      with:
+        arch: ${{ matrix.job.foreign_arch }}
+        distro: ${{ matrix.job.foreign_distro }}
+        githubToken: ${{ github.token }}
+        install: |
+          ${{ env.INSTDEPS }} curl
+          ${{ env.INSTCARGO }} --default-host ${{ matrix.job.target }}
+        run: |
+          test -f dotcargo.tgz && tar xCf ${HOME} dotcargo.tgz || true
+          source "$HOME/.cargo/env"
+          cargo build --release --target ${{ matrix.job.target }} ${{ matrix.job.buildopts }}
+          for bin in cli ncli service; do
+            path=target/${{ matrix.job.target }}/release/cherryrgb_${bin}
+            test -f ${path} && strip ${path} || true
+          done
+          tar czCf ${HOME} dotcargo.tgz .cargo
+    - name: Update target cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          target
+          dotcargo.tgz
+        key: ${{ matrix.job.target }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          ${{ matrix.job.target }}
+        enableCrossOsArchive: true
+    - name: Strip native binaries
+      if: ${{ matrix.job.native }}
+      shell: bash
+      run: |
+          case "${{ matrix.job.target }}" in
+            *linux*)
+              for bin in cli ncli service; do
+                path=target/${{ matrix.job.target }}/release/cherryrgb_${bin}
+                test -f ${path} && strip ${path} || true
+              done
+            ;;
+            *windows*)
+              strip target/${{ matrix.job.target }}/release/cherryrgb_cli.exe
+            ;;
+            *)
+              strip target/${{ matrix.job.target }}/release/cherryrgb_cli
+            ;;
+          esac
+    - name: Collect artifacts
+      shell: bash
+      run: |
+          mkdir -p artifacts/bin
+          case "${{ matrix.job.target }}" in
+            *linux*)
+              for bin in cli ncli service; do
+                path=target/${{ matrix.job.target }}/release/cherryrgb_${bin}
+                test -f ${path} && cp -av ${path} artifacts/bin/ || true
+              done
+              miscfiles="*.md LICENSE service/etc udev docs examples"
+            ;;
+            *windows*)
+              cp -av target/${{ matrix.job.target }}/release/cherryrgb_cli.exe artifacts/bin/
+              miscfiles="*.md LICENSE docs examples"
+            ;;
+            *)
+              cp -av target/${{ matrix.job.target }}/release/cherryrgb_cli artifacts/bin/
+              miscfiles="*.md LICENSE docs examples"
+            ;;
+          esac
+          cp -av ${miscfiles} artifacts/
+          tgz=${{ matrix.assetprefix }}-${{ github.ref_name }}-${{ matrix.job.assetname }}.tar.gz
+          tar cvzCf artifacts ${tgz} .
+          echo "${GITHUB_REF}" > github-ref
+          echo "${GITHUB_SHA}" > commithash
+    - name: Save artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: cherryrgb-rs
+        path: |
+          github-ref
+          commithash
+          ${{ matrix.assetprefix }}-${{ github.ref_name }}-${{ matrix.job.assetname }}.tar.gz
+
+  deploy:
+    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+    needs: [build]
+    name: Call
+    uses: ./.github/workflows/new-cd.yml
+    secrets: inherit
+    with:
+      artifact-id: cherryrgb-rs


### PR DESCRIPTION
# Description

## Type of change

- [x] New workflow, meant to replace the existing one
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Adds/updates Documentation

- [x] I have performed a self-review of my own code
- [x] I have performed tests of the ne workflows (except publish to cargo)
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have implemented respective test(s)
- [ ] I have run lints and tests (cargo fmt && cargo clippy && cargo test) that prove my fix is effective or that my feature works

## Current state

- The new workflow builds on **all** linux targets with ``--all --features uhid``.
- Cross compilation was replaced by builds with native containers running in qemu in order to eliminate problems with installing libclang clang and llvm.
- Introduced caching of ~/.cargo and target directories to speed up builds.
- Prepared container images (with dependencies and stable cargo installed) are tagged and pushed to ghcr.io for further speedup. As a side effect, these are published as "packages" as well.
- As a maintainer, where applicable, the actions can be invoked manually:
  - Running checks on other branches than master.
  - Republish to cargo.
- Creating a release works like before: Pushing a tag to master. Tag format now is checked by a regex.
- Names of released tar archives, can be adjusted by properties ``assetprefix`` and ``assetname`` in new-ci.yml. The new assetprefix is "cherryrgb-rs" (the project name), previously it was "cherryrgb_cli".
- Triggers:
  - pull request: Only the checks are run. If it's a PR for docs or workflows, checks make no sense and therefore ar skipped,
  - push on master: Checks and matrix build run. Matrix build produces artifacts which can be downloaded and verified before making a release.
  - push tag on master Checks, matrix build and publish (new-cd.yml) are run only if tag matches pattern.
  - workflow_dispatch (Manual via GUI by maintainer): Same as push on master above.

## Caveat:
For pushing container images, the default github token has not enough permissions. To adjust that, in the github GUI,
go the Project settings, select ``Actions->General`` in the left pane, then scroll down to ``Workflow permissions`` and select ``Read and write permissions`` there, hit the ``Save`` button.