### PR TITLE
Switch back to cross-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   DEBIAN_FRONTEND: noninteractive
-  INSTDEPS: "apt-get update && apt-get install -y libclang-dev clang llvm"
-  INSTCARGO: "curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | bash -s -- -y -q"
+  INSTDEPS: "apt-get update && apt-get install -y libclang-dev clang"
+  RUSTFLAGS: "-C link-arg=-s"
 
 jobs:
   test:
@@ -113,27 +113,29 @@ jobs:
           target: aarch64-unknown-linux-gnu
           buildopts: "--all --features uhid"
           native: false
-          foreign_arch: aarch64
-          foreign_distro: ubuntu_latest
+          imagetag: edge
         - os: ubuntu-latest
           assetname: linux-i686
           target: i686-unknown-linux-gnu
           buildopts: "--all --features uhid"
           native: false
-          foreign_arch: i686
-          foreign_distro: ubuntu_latest
+          imagetag: edge
         - os: ubuntu-latest
           assetname: linux-ppc64le
           target: powerpc64le-unknown-linux-gnu
           buildopts: "--all --features uhid"
           native: false
-          foreign_arch: ppc64le
-          foreign_distro: ubuntu_latest
+          imagetag: edge
     runs-on: ${{ matrix.job.os }}
     name: Build for ${{ matrix.job.target }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Initialize CARGO_HOME
+      shell: bash
+      # The following must be set from within a shell, because HOME is not preset in a github runner context.
+      # See also https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+      run: echo "CARGO_HOME=${HOME}/.cargo-${{ matrix.job.target }}" >> "$GITHUB_ENV"
     - name: Install native build dependencies
       if: ${{ matrix.job.installdeps && matrix.job.native }}
       run: sudo sh -c "${{ env.INSTDEPS }}"
@@ -142,67 +144,49 @@ jobs:
       with:
         path: |
           target
-          dotcargo.tgz
+          ${{ env.CARGO_HOME }}/bin/
+          ${{ env.CARGO_HOME }}/registry/index/
+          ${{ env.CARGO_HOME }}/registry/cache/
+          ${{ env.CARGO_HOME }}/git/db/
         key: ${{ matrix.job.target }}-${{ hashFiles('Cargo.lock') }}
         restore-keys: |
           ${{ matrix.job.target }}
         enableCrossOsArchive: true
     - name: Build native
       if: ${{ matrix.job.native }}
-      shell: bash
       run: |
-        test -f dotcargo.tgz && tar xCf ${HOME} dotcargo.tgz || true
         cargo build --release --target ${{ matrix.job.target }} ${{ matrix.job.buildopts }}
-        tar czCf ${HOME} dotcargo.tgz .cargo
-    - name: Build in container
+    - name: Install cross-rs
+      id: install_cross
+      if: ${{ ! matrix.job.native }}
+      run: test -f ${{ env.CARGO_HOME }}/bin/cross && echo "::notice::cross provided from cache, skipping install" || cargo install cross
+    - name: Configure cross
+      id: configure_cross
+      if: ${{ ! matrix.job.native }}
+      run: |
+        cat > Cross.toml << EOM
+        [target.${{ matrix.job.target }}]
+        image = "ghcr.io/cross-rs/${{ matrix.job.target }}:${{ matrix.job.imagetag }}"
+        pre-build = ["${{ env.INSTDEPS }}"]
+        EOM
+    - name: Build with cross
       id: build_foreign
       if: ${{ ! matrix.job.native }}
-      uses: felfert/run-on-arch-action@custom
-      with:
-        arch: ${{ matrix.job.foreign_arch }}
-        distro: ${{ matrix.job.foreign_distro }}
-        githubToken: ${{ github.token }}
-        cachedImageTag: "rust-stable-toolchain-with-libclang-${{ matrix.job.foreign_arch }}-${{ matrix.job.foreign_distro }}"
-        install: |
-          ${{ env.INSTDEPS }} curl
-          ${{ env.INSTCARGO }} --default-host ${{ matrix.job.target }}
-        run: |
-          test -f dotcargo.tgz && tar xCf ${HOME} dotcargo.tgz || true
-          source "$HOME/.cargo/env"
-          cargo build --release --target ${{ matrix.job.target }} ${{ matrix.job.buildopts }}
-          for bin in cli ncli service; do
-            path=target/${{ matrix.job.target }}/release/cherryrgb_${bin}
-            test -f ${path} && strip ${path} || true
-          done
-          tar czCf ${HOME} dotcargo.tgz .cargo
+      run: |
+        ${{ env.CARGO_HOME }}/bin/cross build --release --target ${{ matrix.job.target }} ${{ matrix.job.buildopts }}
     - name: Update target cache
       uses: actions/cache@v3
       with:
         path: |
           target
-          dotcargo.tgz
+          ${{ env.CARGO_HOME }}/bin/
+          ${{ env.CARGO_HOME }}/registry/index/
+          ${{ env.CARGO_HOME }}/registry/cache/
+          ${{ env.CARGO_HOME }}/git/db/
         key: ${{ matrix.job.target }}-${{ hashFiles('Cargo.lock') }}
         restore-keys: |
           ${{ matrix.job.target }}
         enableCrossOsArchive: true
-    - name: Strip native binaries
-      if: ${{ matrix.job.native }}
-      shell: bash
-      run: |
-          case "${{ matrix.job.target }}" in
-            *linux*)
-              for bin in cli ncli service; do
-                path=target/${{ matrix.job.target }}/release/cherryrgb_${bin}
-                test -f ${path} && strip ${path} || true
-              done
-            ;;
-            *windows*)
-              strip target/${{ matrix.job.target }}/release/cherryrgb_cli.exe
-            ;;
-            *)
-              strip target/${{ matrix.job.target }}/release/cherryrgb_cli
-            ;;
-          esac
     - name: Collect artifacts
       shell: bash
       run: |


### PR DESCRIPTION
# Description

- Removed separate strip step. Build now produces stripped binaries using RUSTFLAGS.
- Removed dotcargo.tgz workaround. (Not necessary anymore wit cross build)
- Skip cross install if found in cache from an earlier run.
- Use separate CARGO_HOME per target for proper caching.

## Type of change

- [x] Fix for ci.yaml not working (anymore) with recent github updates.

## Motivation
See my remarks [here](https://github.com/skraus-dev/cherryrgb-rs/commit/149482de4522776d6261bcd04db189d3b7ce7052#commitcomment-112706705)

# Code Checklist

- [x] I have performed a self-review of my own code
- [x] I have performed tests of the ne workflows (except publish to cargo)
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have implemented respective test(s)
- [ ] I have run lints and tests (cargo fmt && cargo clippy && cargo test) that prove my fix is effective or that my feature works

## Notes to @skraus-dev 
- Since we don't push container images anymore, you can revert the permissions in your settings.
- You will probably find it difficult to delete the "packages" (a.k.a. docker images) that were created by the runs of the ci workflow from my previous PR. This is due to the fact, that this feature is very new and github did not yet update the WebGUI. So, currently deleting packages is possible via REST api only. Here are 2 scripts for that purpose:

### gh-listpackages
```bash
#!/bin/bash
curl -sL \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer ${GH_TOKEN_CLASSIC}"\
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/user/packages?package_type=container | jq -r '.[].name '

```
### gh-rmpackage
```bash
#!/bin/bash
#set -x
for pkg in "$@" ; do
    name=$(echo $pkg | sed -e 's!/!%2f!g')
    curl -L \
        -H "Accept: application/vnd.github+json" \
        -H "Authorization: Bearer ${GH_TOKEN_CLASSIC}"\
        -H "X-GitHub-Api-Version: 2022-11-28" \
        https://api.github.com/user/packages/container/${name}/versions
    curl -L \
        -X DELETE \
        -H "Accept: application/vnd.github+json" \
        -H "Authorization: Bearer ${GH_TOKEN_CLASSIC}"\
        -H "X-GitHub-Api-Version: 2022-11-28" \
        https://api.github.com/user/packages/container/${name}
done
```

Both scripts require an env variable ``GH_TOKEN_CLASSIC`` with the value of a **classic** personal token. This token can be created in your[ personal settings](https://github.com/settings/tokens) and must have the following permissions:
- `read:packages`
- `write:packages`
- `delete:packages`




