### PR TITLE
Query rusb for detach support

### DIFF
--- a/cherryrgb/src/lib.rs
+++ b/cherryrgb/src/lib.rs
@@ -247,8 +247,8 @@ impl CherryKeyboard {
             }
         }
 
-        // Skip kernel driver detachment for non-unix platforms
-        if cfg!(unix) {
+        // Skip kernel driver detachment if unsupported
+        if rusb::supports_detach_kernel_driver() {
             device_handle
                 .set_auto_detach_kernel_driver(true)
                 .map_err(|e| {


### PR DESCRIPTION
# Description

This PR provides a very minimal change for the condition of enabling the `auto_detach_kernel` feature.
Instead of enabling it on all unix platforms, it actually queries the relevant flag of libusb. rusb [provides
a function](https://docs.rs/rusb/latest/rusb/fn.supports_detach_kernel_driver.html) for that specifically.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Code Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have implemented respective test(s)
- [x] I have run lints and tests (cargo fmt && cargo clippy && cargo test) that prove my fix is effective or that my feature works

@skraus-dev PS: Now that CI/CD is working again and my solution to #22 (introducing the VHID driver) is here, I would **LOVE** to see a new release soon. (I already have an updated rpm spec file for fedora packaging and as soon as the next version is available, I can provide Fedora packages with preconfigured systemd service).