### PR TITLE
Attempt to fix docs.rs build

### DIFF
--- a/cherryrgb/Cargo.toml
+++ b/cherryrgb/Cargo.toml
@@ -24,3 +24,6 @@ serde_json = "1.0"
 
 [target.'cfg(all(target_os = "linux"))'.dependencies]
 uhid-virt = { version = "0.0.6", optional = true }
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
# Description

I'm not quite shure why exactly the build at docs.rs has failed, but one thing was overlooked for shure: Having the uhid feature, now we must enable all-features for this build.

## Type of change

- [x] Metadata (non-breaking change which affects build on docs.rs)

# Code Checklist

- [x] I have performed a self-review of my own code
