### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cherryrgb"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "binrw",
  "hex",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "cherryrgb_cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "cherryrgb",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "cherryrgb_ncli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "cherryrgb",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "cherryrgb_service"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "cherryrgb",


### PR DESCRIPTION
# Description

This PR fixes a small glitch in the latest release: Cargo.lock is not up-to-date (It still references 0.2.6). This affects the **source archives** of the github release only. It does NOT affect the release on crates.io.

## Type of change

Please delete options that are not relevant.

- [x] Updates Cargo.lock

@skraus-dev Here is a pre-push hook script, that checks Cargo.lock whenever a tag is pushed and prevents the push if Cargo.lock is not up-to-date:

```bash
#!/bin/bash
## hook to check if Cargo.lock is up to date when pushing a tag

tagref=$(grep -Po 'refs/tags/([^ ]*) ' </dev/stdin | head -n1 | cut -c11- | tr -d '[:space:]')

if [[ "$tagref" == ""  ]]; then
    ## pushing without --tags , exit normally
    exit 0
fi

echo "Checking Cargo.lock state ..."
if cargo fetch --locked >/dev/null 2>&1 ; then
    # Cargo.lock is up-to-date
    exit 0
fi

echo "Pushing a tag, but Cargo.lock is out of date" >&2
exit 1
```

In order to use this, save this as `.git/hooks/pre-push` in your local working copy and make it executable.
