### PR TITLE
Add check for Cargo.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,15 @@ jobs:
       - name: Publish dry-run
         run: cargo publish -p cherryrgb --dry-run
 
+  check-cargo-lock:
+    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+    name: Check Cargo.lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - run: cargo fetch --locked
+
   clean:
     if: ${{ github.event_name != 'pull_request' }} # If this is a pull request, stop here
     name: Clean before matrix build
@@ -224,7 +233,7 @@ jobs:
 
   deploy:
     if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
-    needs: [build]
+    needs: [build, check-cargo-lock]
     name: Call
     uses: ./.github/workflows/cd.yml
     secrets: inherit


### PR DESCRIPTION
# Description

This PR adds a check for an up-to-date Cargo.lock which prevents publishing when a tag is pushed, but Cargo.lock is not up-to-date.
## Type of change

- [x] New feature in ci.yml

<!-- If change is related to documentation only, please delete thefollowing checklist section -->
# Code Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have implemented respective test(s)
- [x] I have run manual push tests on my fork
