### PR TITLE
Migrate from StructOpt+clap v2.x to clap v4.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,52 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -29,7 +69,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -131,6 +171,7 @@ name = "cherryrgb"
 version = "0.2.7"
 dependencies = [
  "binrw",
+ "clap",
  "hex",
  "log",
  "rgb",
@@ -149,9 +190,9 @@ version = "0.2.7"
 dependencies = [
  "anyhow",
  "cherryrgb",
+ "clap",
  "log",
  "simple_logger",
- "structopt",
 ]
 
 [[package]]
@@ -160,10 +201,10 @@ version = "0.2.7"
 dependencies = [
  "anyhow",
  "cherryrgb",
+ "clap",
  "log",
  "serde_json",
  "simple_logger",
- "structopt",
 ]
 
 [[package]]
@@ -172,6 +213,7 @@ version = "0.2.7"
 dependencies = [
  "anyhow",
  "cherryrgb",
+ "clap",
  "ctrlc",
  "file-mode",
  "log",
@@ -179,7 +221,6 @@ dependencies = [
  "rgb",
  "serde_json",
  "simple_logger",
- "structopt",
  "systemd-journal-logger",
 ]
 
@@ -195,18 +236,53 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "once_cell",
+ "strsim",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -255,7 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
 dependencies = [
  "nix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -296,6 +372,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "file-mode"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,15 +419,6 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -345,6 +433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +451,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -412,6 +529,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
@@ -499,30 +622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +679,20 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "rustversion"
@@ -661,33 +774,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -701,7 +790,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -747,12 +836,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "terminal_size"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "unicode-width",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -808,16 +898,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -843,12 +927,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -884,7 +962,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -893,13 +980,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -909,10 +1011,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -921,10 +1035,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -933,13 +1059,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cherryrgb_cli"
+description = "Test tool for Cherry RGB Keyboard"
 version.workspace = true
 edition.workspace = true
 publish = false
@@ -21,8 +22,8 @@ publish = false
 
 [dependencies]
 cherryrgb = { path = "cherryrgb" }
+clap = { version = "4.3.1", features = ["derive", "cargo", "wrap_help"] }
 anyhow = "1.0"
-structopt = "0.3"
 log = "0.4"
 
 [dependencies.simple_logger]

--- a/cherryrgb/Cargo.toml
+++ b/cherryrgb/Cargo.toml
@@ -20,6 +20,7 @@ rusb = "0.9"
 serde = { version = "1.0.160", features = ["derive"] }
 strum = "0.24.1"
 strum_macros = "0.24.3"
+clap = { version = "4.3.1", features = ["derive"] }
 serde_json = "1.0"
 
 [target.'cfg(all(target_os = "linux"))'.dependencies]

--- a/cherryrgb/src/lib.rs
+++ b/cherryrgb/src/lib.rs
@@ -73,7 +73,6 @@ pub use models::RpcAnimation;
 pub use models::{Brightness, CustomKeyLeds, LightingMode, Packet, Payload, Speed};
 pub use rgb;
 pub use rusb;
-pub use strum;
 #[cfg(all(target_os = "linux", feature = "uhid"))]
 pub use vkbd::VirtKbd;
 

--- a/cherryrgb/src/models.rs
+++ b/cherryrgb/src/models.rs
@@ -5,9 +5,10 @@ use crate::{
 };
 
 use binrw::{binrw, until_eof, BinRead, BinWrite, BinWriterExt, Endian};
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
-use strum_macros::{EnumProperty, EnumString, EnumVariantNames};
+use strum_macros::{EnumProperty, EnumString};
 
 /// Mode attributes:
 /// -> C: Supports color option
@@ -16,8 +17,9 @@ use strum_macros::{EnumProperty, EnumString, EnumVariantNames};
 #[binrw]
 #[brw(repr = u8)]
 #[derive(
-    Clone, Eq, PartialEq, Debug, EnumString, EnumProperty, EnumVariantNames, Serialize, Deserialize,
+    Clone, Eq, PartialEq, Debug, EnumString, EnumProperty, ValueEnum, Serialize, Deserialize,
 )]
+#[clap(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum LightingMode {
     #[strum(props(attr = "CS"))]
@@ -71,7 +73,8 @@ pub enum UsbPollingRate {
 /// LED animation speed
 #[binrw]
 #[brw(repr = u8)]
-#[derive(Clone, Eq, PartialEq, Debug, EnumString, EnumVariantNames, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Debug, EnumString, ValueEnum, Serialize, Deserialize)]
+#[clap(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum Speed {
     VeryFast = 0,
@@ -84,7 +87,8 @@ pub enum Speed {
 /// LED brightness
 #[binrw]
 #[brw(repr = u8)]
-#[derive(Clone, Eq, PartialEq, Debug, EnumString, EnumVariantNames, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Debug, EnumString, ValueEnum, Serialize, Deserialize)]
+#[clap(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum Brightness {
     Off = 0,

--- a/ncli/Cargo.toml
+++ b/ncli/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "cherryrgb_ncli"
+description = "Client for service-based Cherry RGB Keyboard"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
 [dependencies]
 cherryrgb = { path = "../cherryrgb" }
+clap = { version = "4.3.1", features = ["derive", "cargo", "wrap_help"] }
 anyhow = "1.0"
-structopt = "0.3"
 log = "0.4"
 serde_json = "1.0.96"
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cherryrgb_service"
+description = "Service daemon and UHID driver for Cherry RGB Keyboard"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
@@ -7,8 +8,8 @@ publish.workspace = true
 [dependencies]
 cherryrgb = { path = "../cherryrgb" }
 anyhow = "1.0"
-structopt = "0.3"
 log = "^0.4.17"
+clap = { version = "4.3.1", features = ["derive", "cargo", "wrap_help"] }
 ctrlc = { version = "3.2.5", features = ["termination"] }
 serde_json = "1.0.96"
 rgb = { version = "0.8", features = ["serde"] }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use cherryrgb::{self, CherryKeyboard, CustomKeyLeds, RpcAnimation, VirtKbd};
+use clap::Parser;
 use file_mode::ModePath;
 use log::LevelFilter;
 use nix::unistd::{chown, Group};
@@ -9,43 +10,46 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::{thread, time};
-use structopt::StructOpt;
 use systemd_journal_logger::{connected_to_journal, JournalLog};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const NAME: &str = env!("CARGO_PKG_NAME");
 
-#[derive(StructOpt, Debug, Clone)]
-#[structopt(name = NAME, about = "Service for cherryrgb_ncli")]
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
 struct Opt {
     /// Enable debug output
-    #[structopt(short, long)]
+    #[arg(short, long)]
     debug: bool,
 
-    #[structopt(
+    #[arg(
+        short,
         long,
         help = "Must be specified if multiple cherry products are detected."
     )]
     product_id: Option<String>,
 
-    #[structopt(
+    #[arg(
         name = "socket",
+        short,
         long,
         help = "Path of listening socket to create.",
         default_value = "/run/cherryrgb.sock"
     )]
     socket_path: String,
 
-    #[structopt(
+    #[arg(
         name = "socketmode",
+        short = 'm',
         long,
         help = "Permissions of the socket.",
         default_value = "0664"
     )]
     socket_mode: String,
 
-    #[structopt(
+    #[arg(
         name = "socketgroup",
+        short = 'g',
         long,
         help = "Group of the socket.",
         default_value = "root"
@@ -225,7 +229,7 @@ fn get_u16_from_string(pid: Option<String>) -> Option<u16> {
 }
 
 fn main() -> Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     if connected_to_journal() {
         // If the output streams of this process are directly connected to the

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,70 +1,68 @@
 use std::{convert::TryFrom, io::Read, path::PathBuf};
 
 use anyhow::{anyhow, Context, Result};
-use cherryrgb::strum::VariantNames;
 use cherryrgb::{
     self, read_color_profile, rgb, Brightness, CherryKeyboard, CustomKeyLeds, LightingMode,
     OwnRGB8, Speed,
 };
-use structopt::StructOpt;
+use clap::{Parser, Subcommand};
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct AnimationArgs {
     /// Set LED mode
-    #[structopt(possible_values = LightingMode::VARIANTS)]
+    #[arg(value_enum)]
     mode: LightingMode,
 
     /// Set speed
-    #[structopt(possible_values = Speed::VARIANTS)]
+    #[arg(value_enum)]
     speed: Speed,
 
     /// Color (e.g ff00ff)
     color: Option<OwnRGB8>,
 
     /// Enable rainbow colors
-    #[structopt(short, long)]
+    #[arg(short, long)]
     rainbow: bool,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct CustomColorOptions {
     colors: Vec<OwnRGB8>,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct ColorProfileFileOptions {
-    #[structopt(parse(from_os_str))]
     file_path: PathBuf,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 enum CliCommand {
     Animation(AnimationArgs),
     CustomColors(CustomColorOptions),
     ColorProfileFile(ColorProfileFileOptions),
 }
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "cherryrgb", about = "Test tool for Cherry RGB Keyboard")]
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
 struct Opt {
     /// Enable debug output
-    #[structopt(short, long)]
+    #[arg(short, long)]
     debug: bool,
 
-    #[structopt(long)]
+    #[arg(long)]
     product_id: Option<u16>,
 
     // Subcommand
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     command: CliCommand,
 
     /// Set brightness
-    #[structopt(short, long, default_value = "full", possible_values = Brightness::VARIANTS)]
+    #[arg(short, long, default_value_t = Brightness::Full, value_enum)]
     brightness: Brightness,
 }
 
 fn main() -> Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     // Search / init usb keyboard
     let devices =


### PR DESCRIPTION
# Description

This PR migrates from using structopt on top of clap v2.x to just clap v4.x.

Motivation:
- StructOpt is in maintenance mode and no longer developed further
- The functionality of StructOpt has been integrated into clap since v3.x
- With current clap, we get the opportunity to use advanced features like:
  - Generation of Unix man pages at build time using [clap_mangen](https://docs.rs/clap_mangen/0.2.12/clap_mangen/)
  - Generation of shell-completion scripts at build time using [clap_complete](https://docs.rs/clap_complete/latest/clap_complete/)

See also: [The clap FAQ](https://docs.rs/clap/latest/clap/_faq/index.html)

Next steps/PR(s) will be:
- Reorganize source of commands so that all can be pulled in by a [cargo xtask](https://github.com/matklad/cargo-xtask)
- Implement that cargo xtask which will create man pages and shell-completion scripts
- CI: Add generated files to binary releases

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Adds/updates Documentation

<!-- If change is related to documentation only, please delete thefollowing checklist section -->
# Code Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have implemented respective test(s)
- [x] I have run lints and tests (cargo fmt && cargo clippy && cargo test) that prove my fix is effective or that my feature works
