### PR TITLE
Include toplevel directory in tarballs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,8 +221,9 @@ jobs:
             ;;
           esac
           cp -av ${miscfiles} artifacts/
-          tgz=${{ matrix.assetprefix }}-${{ github.ref_name }}-${{ matrix.job.assetname }}.tar.gz
-          tar cvzCf artifacts ${tgz} .
+          afname="${{ matrix.assetprefix }}-${{ github.ref_name }}-${{ matrix.job.assetname }}"
+          mv artifacts "${afname}"
+          tar cvzf "${afname}.tar.gz" "${afname}"
           echo "${GITHUB_REF}" > github-ref
           echo "${GITHUB_SHA}" > commithash
     - name: Save artifacts


### PR DESCRIPTION
# Description

This PR changes the tarballs that are created during build in CI. Until now, the tarballs did unpack in the current directory. With the increasing number of files/directories, this clutters the current directory and is not userfriendly. Therefore , from now on, the tarballs contain a single toplevel diretory which is named after the tarball-basename and contains everything else.

## Type of change

- [x] CI improvement

<!-- If change is related to documentation only, please delete thefollowing checklist section -->
# Code Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have implemented respective test(s)
- [x] I have tested CI manually in my fork
- [ ] I have run lints and tests (cargo fmt && cargo clippy && cargo test) that prove my fix is effective or that my feature works
