### PR TITLE
Filter mouse movement packets from firmware 0105

### DIFF
--- a/cherryrgb/src/lib.rs
+++ b/cherryrgb/src/lib.rs
@@ -444,7 +444,7 @@ impl CherryKeyboard {
         {
             Ok(len) => {
                 // Bogus event data has bit 3 set in the 3rd byte
-                if len >= 3 && buf[2] >= 8 {
+                if (len >= 3 && buf[2] >= 8) || (len == 9 && buf[0] == 5) {
                     log::debug!(" - BOGUS read {} bytes: {:?} filtered", len, &buf[..len]);
                     return Ok(());
                 }


### PR DESCRIPTION
# Description

This PR updates the expression for filtering unwanted event packets (mouse movement) that are produced instead of the previous bogus key events after updating to firmware 0105.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- If change is related to documentation only, please delete thefollowing checklist section -->
# Code Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have implemented respective test(s)
- [x] I have run lints and tests (cargo fmt && cargo clippy && cargo test) that prove my fix is effective or that my feature works
